### PR TITLE
Fix default value of error code and message

### DIFF
--- a/loginlog/loginlog.class.php
+++ b/loginlog/loginlog.class.php
@@ -183,7 +183,7 @@ class loginlog extends ModuleObject
 	{
 	}
 
-    public function makeObject($code = '', $msg = '')
+    public function makeObject($code = 0, $msg = 'success')
     {
         return class_exists('BaseObject') ? new BaseObject($code, $msg) : new Object($code, $msg);
     }


### PR DESCRIPTION
라이믹스와 XE 에서 사용되는 BaseObject 는 기본 값으로 error code 0과 message 'success' 를 사용합니다.
공백 텍스트를 반환할 경우에 미솔의 테스트 환경에서 문제가 발생하였습니다.
기본 값을 코어의 기본값과 맞추어서 로그인이 안되는 상황을 수정합니다.

관련 이슈: https://github.com/xe-public/xe-module-loginlog/issues/4