### PR TITLE
return 뒤에 break 문제 있으면 php 7.1에서는 에러를 발생 시킵니다.

### DIFF
--- a/loginlog/libs/PHPExcel/Calculation/Functions.php
+++ b/loginlog/libs/PHPExcel/Calculation/Functions.php
@@ -571,7 +571,6 @@ class PHPExcel_Calculation_Functions {
 				return 4;
 		} elseif(is_array($value)) {
 				return 64;
-				break;
 		} elseif(is_string($value)) {
 			//	Errors
 			if ((strlen($value) > 0) && ($value{0} == '#')) {


### PR DESCRIPTION
return 뒤에 break 문제 있으면 php 7.1에서는 에러를 발생 시킵니다.